### PR TITLE
feat: migrate project to Next.js 15 with TypeScript

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,8 +1,24 @@
+import { NextRequest } from 'next/server';
+
+type Role = 'system' | 'user' | 'assistant';
+
+type ChatMessage = {
+  role: Role;
+  content: string;
+};
+
+type ChatRequestBody = {
+  messages: ChatMessage[];
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+};
+
 const DEFAULT_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4-1106-preview';
 const DEFAULT_TEMPERATURE = 0.9;
 const DEFAULT_MAX_TOKENS = 150;
 
-export async function POST(request) {
+export async function POST(request: NextRequest) {
   const apiKey = process.env.OPENAI_API_KEY;
   const endpoint = process.env.OPENAI_ENDPOINT ?? 'https://api.openai.com/v1';
 
@@ -13,10 +29,10 @@ export async function POST(request) {
     );
   }
 
-  let payload;
+  let payload: ChatRequestBody;
 
   try {
-    payload = await request.json();
+    payload = (await request.json()) as ChatRequestBody;
   } catch (error) {
     return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,13 @@
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
 import './globals.css';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'ChatGPT Demo',
   description: 'A minimal chat interface powered by the OpenAI Chat Completions API.',
 };
 
-export default function RootLayout({ children }) {
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html lang="en">
       <body className="bg-gray-100 text-gray-900 min-h-screen">{children}</body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,29 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 
-const SYSTEM_MESSAGE = {
+type Role = 'system' | 'user' | 'assistant';
+
+interface Message {
+  role: Role;
+  content: string;
+}
+
+interface ChatCompletionResponse {
+  choices?: {
+    message?: {
+      content?: string;
+    };
+  }[];
+}
+
+const SYSTEM_MESSAGE: Message = {
   role: 'system',
   content: "You're a helpful chat bot. Answer short and concise in 150 tokens only.",
 };
 
 export default function Home() {
-  const [messages, setMessages] = useState([SYSTEM_MESSAGE]);
+  const [messages, setMessages] = useState<Message[]>([SYSTEM_MESSAGE]);
   const [userInput, setUserInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -17,7 +32,7 @@ export default function Home() {
     [messages],
   );
 
-  const handleSubmit = async (event) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!userInput.trim()) {
@@ -25,7 +40,10 @@ export default function Home() {
     }
 
     const trimmedInput = userInput.trim();
-    const nextMessages = [...messages, { role: 'user', content: trimmedInput }];
+    const nextMessages: Message[] = [
+      ...messages,
+      { role: 'user', content: trimmedInput },
+    ];
 
     setMessages(nextMessages);
     setUserInput('');
@@ -44,7 +62,7 @@ export default function Home() {
         throw new Error('Request failed');
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as ChatCompletionResponse;
       const assistantMessage = data?.choices?.[0]?.message?.content;
 
       if (assistantMessage) {
@@ -61,7 +79,7 @@ export default function Home() {
           },
         ]);
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('There was an error with the API request', error);
       setMessages((current) => [
         ...current,
@@ -75,10 +93,10 @@ export default function Home() {
     }
   };
 
-  const messageAlignment = (role) =>
+  const messageAlignment = (role: Role) =>
     role === 'user' ? 'justify-end text-right' : 'justify-start text-left';
 
-  const messageBubbleStyles = (role) =>
+  const messageBubbleStyles = (role: Role) =>
     role === 'user'
       ? 'bg-blue-500 text-white'
       : 'bg-white text-gray-800 border border-gray-200';

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -6,16 +6,21 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "14.1.0",
+    "next": "15.0.0-canary.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",
     "postcss": "8.4.31",
-    "tailwindcss": "3.3.5"
+    "tailwindcss": "3.3.5",
+    "@types/node": "20.11.25",
+    "@types/react": "18.2.55",
+    "@types/react-dom": "18.2.19",
+    "typescript": "5.4.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- upgrade the app to Next.js 15 canary and add TypeScript tooling support
- convert the app router layout, home page, and chat API route to TypeScript with stronger typing
- add a strict tsconfig and Next.js TypeScript environment declarations

## Testing
- npm install *(fails: registry access is restricted in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8cbb2310832784652e8fe36b8ceb